### PR TITLE
add support for disabling parallel I/O for output files

### DIFF
--- a/bin/mympingpong.py
+++ b/bin/mympingpong.py
@@ -305,7 +305,7 @@ class MyPingPong(object):
         if parallel_io or self.rank == 0:
             self.writehdf5(data, attrs, failed, fail, parallel_io=parallel_io)
         else:
-            self.log.debug("sending data to master rank...")
+            self.log.debug("sending data to master rank (blocking until master rank receives)...")
             self.comm.send((self.rank, self.name, self.core, self.size, data, failed, fail), dest=0, tag=123)
             self.log.debug("data sent to master rank!")
 
@@ -377,7 +377,7 @@ class MyPingPong(object):
         if not parallel_io:
             # receive data for other (n-1) ranks
             for rank in range(self.size)[1:]:
-                self.log.debug("receiving data from rank %d...", rank)
+                self.log.debug("receiving data from rank %d (blocking MPI recv)...", rank)
                 foo = self.comm.recv(source=rank, tag=123)
                 self.log.debug("data from rank %d received!", rank)
                 all_tuples.append(foo)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ from vsc.install.shared_setup import action_target, sdw
 
 PACKAGE = {
     'name': 'mympingpong',
-    'version': '0.7.1',
+    'version': '0.8.0',
     'install_requires': [
         'vsc-base >= 2.4.16',
         'numpy >= 1.8.2',


### PR DESCRIPTION
Parallel HDF5 doesn't work on an NFS-mounted filesystem, which is sometimes the only shared filesystem available.

This PR adds support for `--disable-parallel-io` to make `mympingpong` use serial I/O instead, after receiving all results from the `n-1` other ranks.

This should probably only be used in modestly small setups...